### PR TITLE
add /all watch path

### DIFF
--- a/src/mar/beacon/appeal.hoon
+++ b/src/mar/beacon/appeal.hoon
@@ -9,7 +9,6 @@
   ++  noun  appeal
   ++  json
     =,  enjs:format
-    |=  =appeal:beacon
     ^-  ^json
     ?+    -.appeal  !!
         %auth

--- a/src/mar/beacon/appeal.hoon
+++ b/src/mar/beacon/appeal.hoon
@@ -3,6 +3,7 @@
 ++  grab
   |%
   ++  noun  appeal:beacon
+  ++  json  (of auto+so send+(se %p) ~):dejs:format
   --
 ++  grow
   |%

--- a/src/mar/beacon/update.hoon
+++ b/src/mar/beacon/update.hoon
@@ -1,0 +1,41 @@
+/-  beacon
+|_  upd=update:beacon
+++  grab
+  |%
+  ++  noun  update:beacon
+  --
+++  grow
+  |%
+  ++  noun  upd
+  ++  json
+    =,  enjs:format
+    |^  ^-  ^json
+    ?-  -.upd
+      %url      (frond 'url' s+url.upd)
+      %pending  (frond 'pending' s+(scot %p ship.upd))
+      %approve  (frond 'approve' s+(scot %p ship.upd))
+      %reject   (frond 'reject' s+(scot %p ship.upd))
+      %init     %+  frond  'init'
+                %-  pairs
+                :~  ['url' s+url.upd]
+                    ['bids' (en-bids bids.upd)]
+                ==
+    ==
+  ::
+    ++  en-bids
+      |=  bids=ships:beacon
+      ^-  ^json
+      :-  %a
+      %+  turn  ~(tap by bids)
+      |=  [ship=@p =fate:beacon]
+      ^-  ^json
+      ?-  fate
+        %clotho    (frond 'pending' s+(scot %p ship))
+        %lachesis  (frond 'approve' s+(scot %p ship))
+        %atropos   (frond 'reject' s+(scot %p ship))
+      ==
+    --
+  --
+++  grad  %noun
+--
+

--- a/src/sur/beacon.hoon
+++ b/src/sur/beacon.hoon
@@ -18,4 +18,11 @@
       [%auth =ship]
       [%burn =ship]
   ==
++$  update
+  $%  [%url =url]
+      [%pending =ship]
+      [%approve =ship]
+      [%reject =ship]
+      [%init =url bids=ships]
+  ==
 --


### PR DESCRIPTION
this adds a `/all` subscription path so their node.js can get updates for everything in a single subscription rather than having to manage a bunch of per-ship subscriptions.

I have added an additional `update` structure and associated `%beacon-update` mark for this. The reason is it really needs a state initialisation structure which the `appeal` structure was lacking. This is maybe not ideal, I considered using `appeal` with just an additional init structure but then I feel like it muddies the meaning of the appeal types.

The possible JSON structures are:

- `{"url": "some.url.com"}` - This is sent whenever the url is changed eg with an `%auto` request. **NOTE:** whenever the url is changed, the subscription to all ships is cancelled and a new request to all ships is sent for the new URL. This causes all ships to revert to a pending authorisation state aka `%clotho` state. **You should therefore change the authorisation state of all ships to pending in your node.js app on receipt of this update.**
- `{"pending": "~sampel-palnet"}` -  a request for authorisation has been sent to the specified ship. **NOTE:** the sentinel app is designed to immediately send an authorisation rejection upon receiving an authorisation request, so this does not represent a pending authorisation in sentinel, it represents a request we've sent for which we have not yet received any response.
- `{"approve": "~sampel-palnet"}` - the given ship has authorised our URL.
- `{"reject": "~sampel-palnet"}` - the given ship has denied the approval *or has received the request but has not yet approved it*. **Again, sentinel auto-rejects all requests immediately on receipt so this does not necessarily represent an actual rejection, it may mean they've received the request but not yet approved, so treat accordingly in your logic.**
- `{"init": {"url": "some.url.com", "bids": [{"pending": "~sampel-palnet"}, ...]}}` - this is sent immediately when you first subscribe. It contains the entire state of the app and should be used to initialise state in the node.js app. The `url` is the currently configured url and the `bids` are an array of either `pending`, `approve` or `reject` objects as described above. These correspond to the `%clotho`, `%lachesis` and `%atropos` `$fate`s that the app uses to represent authorisation status.

Here is the logic I was using to test this:

```
  useEffect(() => {
    async function init() {
      window.urbit = await Urbit.authenticate({
        ship: "zod",
        url: "localhost:8080",
        code: "lidlut-tabwed-pillex-ridrup",
        verbose: false
      });
      window.urbit.subscribe({
        app: "beacon",
        path: "/all",
        event: handleEvent
      });
    };
    init();
  }, []);

  const handleEvent = upd => {
    console.log(upd)
  };
```

idk node.js actually, I assume it works similarly to in-browser & you can use `@urbit/http-api`. The `event` callback given to `Urbit.subscribe` receives one of the objects described above as its argument each time an update comes in.